### PR TITLE
reorganizing, migrating content from penguinclass.com

### DIFF
--- a/_classifieds/2023-11-02-michigan-penguin-for-sale.md
+++ b/_classifieds/2023-11-02-michigan-penguin-for-sale.md
@@ -1,0 +1,25 @@
+---
+layout: classified
+title: "Customflex Fiberglass Penguin - Michigan"
+date: 2023-11-02
+contact: "Doug Roberts"
+email: "mindemova@gmail.com"
+phone: "231-620-3920"
+---
+
+## Customflex Fiberglass Penguin for Sale
+
+**Location:** Traverse City, Michigan  
+**Condition:** Very good  
+**Contact:** Doug Roberts
+
+Customflex fiberglass Penguin in very good condition, located at the Maritime Heritage Alliance in Traverse City, Michigan.
+
+### Contact Information
+- **Name:** Doug Roberts
+- **Email:** [mindemova@gmail.com](mailto:mindemova@gmail.com)
+- **Phone:** [231-620-3920](tel:231-620-3920)
+
+*Posted: November 2, 2023*
+
+*Source: [Penguin Class Wanted Ads](http://penguinclass.com/wanted.html)* 

--- a/_classifieds/2023-11-02-penguin-7444-vermont.md
+++ b/_classifieds/2023-11-02-penguin-7444-vermont.md
@@ -1,0 +1,29 @@
+---
+layout: classified
+title: "Penguin 7444 - West Dover, VT"
+date: 2023-11-02
+contact: "Allan Goldberg"
+email: "allanrgoldberg@gmail.com"
+phone: "802-464-8236"
+---
+
+## Penguin 7444 for Sale
+
+**Location:** West Dover, Vermont  
+**Price:** $275  
+**Condition:** Needs restoration
+
+Penguin 7444 located in West Dover, VT. The boat needs a fresh coat of exterior paint and revarnishing of the interior. The asking price is $275.
+
+### Work Needed
+- Fresh coat of exterior paint
+- Revarnishing of the interior
+
+### Contact Information
+- **Name:** Allan Goldberg
+- **Email:** [allanrgoldberg@gmail.com](mailto:allanrgoldberg@gmail.com)
+- **Phone:** [802-464-8236](tel:802-464-8236)
+
+*Posted: November 2, 2023*
+
+*Source: [Penguin Class Wanted Ads](http://penguinclass.com/wanted.html)* 

--- a/_classifieds/2023-11-02-penguin-7936-pennsylvania.md
+++ b/_classifieds/2023-11-02-penguin-7936-pennsylvania.md
@@ -1,0 +1,34 @@
+---
+layout: classified
+title: "Penguin 7936 - Mechanicsburg, PA"
+date: 2023-11-02
+contact: "Bill Parkes"
+email: "parkes1@comcast.net"
+phone: "717-731-1039"
+---
+
+## Penguin 7936 for Sale
+
+**Location:** Mechanicsburg, Pennsylvania  
+**Price:** $1,000  
+**Condition:** Completely overhauled
+
+Austin hull completely overhauled. New Aluminum mast and older wooden mast. Two sails. Rerigged with Harken blacks and new bailers. Finished bright inside and painted with Interlux Perfection outside. No trailer.
+
+### Specifications
+- **Hull:** Austin hull completely overhauled
+- **Masts:** New Aluminum mast and older wooden mast
+- **Sails:** Two sails included
+- **Rigging:** Rerigged with Harken blacks
+- **Bailers:** New bailers installed
+- **Finish:** Finished bright inside and painted with Interlux Perfection outside
+- **Trailer:** No trailer included
+
+### Contact Information
+- **Name:** Bill Parkes
+- **Email:** [parkes1@comcast.net](mailto:parkes1@comcast.net)
+- **Phone:** [717-731-1039](tel:717-731-1039)
+
+*Posted: November 2, 2023*
+
+*Source: [Penguin Class Wanted Ads](http://penguinclass.com/wanted.html)* 

--- a/_classifieds/2023-11-02-seeking-penguin-1947.md
+++ b/_classifieds/2023-11-02-seeking-penguin-1947.md
@@ -1,0 +1,32 @@
+---
+layout: classified
+title: "Wanted: Penguin 1947"
+date: 2023-11-02
+contact: "Thomas W Anderson, Jr."
+phone: "540-888-3173"
+---
+
+## Wanted: Penguin 1947
+
+**Type:** Wanted to Buy  
+**Location:** Winchester, VA  
+**Contact:** Thomas W Anderson, Jr.
+
+I am seeking the whereabouts of Penguin 1947. This boat was built by my father and mother (Thomas and Mary Anderson) in their basement/garage in Richmond, Virginia and sailed predominantly from the Fishing Bay Yacht club, near Deltaville.
+
+My mother gave it away after my dad died and I would like to find it and see if the current owner might be willing to sell it to me. I had many happy hours growing up with it and would like to share the experience with my grandchildren.
+
+### Boat History
+- **Built by:** Thomas and Mary Anderson
+- **Location:** Richmond, Virginia (basement/garage)
+- **Sailed from:** Fishing Bay Yacht Club, near Deltaville
+- **Current status:** Unknown (given away after father's death)
+
+### Contact Information
+- **Name:** Thomas W Anderson, Jr.
+- **Address:** 770 Glengary Rd., Winchester, VA 22603
+- **Phone:** [540-888-3173](tel:540-888-3173)
+
+*Posted: November 2, 2023*
+
+*Source: [Penguin Class Wanted Ads](http://penguinclass.com/wanted.html)* 

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,9 @@ collections:
   events:
     output: true
     permalink: /events/:year/:month/:day/:title/
+  classifieds:
+    output: true
+    permalink: /classifieds/:year/:month/:day/:title/
 defaults:
   - scope: { path: "", type: posts }
     values: 
@@ -19,4 +22,6 @@ defaults:
       permalink: /news/:year/:month/:day/:title/
   - scope: { path: "", type: events }
     values: { layout: event }
+  - scope: { path: "", type: classifieds }
+    values: { layout: classified }
 markdown: kramdown

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,25 +1,51 @@
 - title: News
   url: /news/
+- title: Classifieds
+  url: /classifieds/
 - title: Events
   url: /events/
 - title: Class
   children:
     - title: About
       url: /class/about/
-    - title: Specs & Rules
-      url: /class/specs/
-    - title: Plans
-      url: /class/plans/
-    - title: Tuning & Rigging
-      url: /class/tuning/
     - title: Bylaws
       url: /class/bylaws/
+    - title: Officers
+      url: /class/officers/
+    - title: Yearbooks
+      url: /class/yearbooks/
     - title: Join
       url: /class/join/
+- title: Penguin
+  children:
+    - title: Specs & Rules
+      url: /penguin/specs/
+    - title: Plans
+      url: /penguin/plans/
+    - title: Tuning & Rigging
+      url: /penguin/tuning/
+    - title: Modern v Classic
+      url: /penguin/modern-v-classic/
+- title: Fleets
+  children:
+    - title: U.S. East Coast
+      url: /fleets/east-coast/
+    - title: U.S. Midwest
+      url: /fleets/midwest/
+    - title: Argentina
+      url: /fleets/argentina/
+    - title: Brazil
+      url: /fleets/brazil/
 - title: Docs
-  url: /docs/
-- title: Hall
-  url: /hall/
+  children:
+    - title: Documents
+      url: /docs/
+    - title: Minutes
+      url: /docs/minutes/
+- title: Results and Champions
+  url: /results-champions/
+- title: Gallery
+  url: /gallery/
 - title: Contact
   url: /contact/
 - title: Archive

--- a/_layouts/classified.html
+++ b/_layouts/classified.html
@@ -1,0 +1,19 @@
+---
+layout: default
+---
+<article class="classified">
+  <h1>{{ page.title }}</h1>
+  <p class="meta">
+    <strong>Posted:</strong> {{ page.date | date_to_long_string }}
+    {%- if page.contact %}
+    <br><strong>Contact:</strong> {{ page.contact }}
+    {%- endif %}
+    {%- if page.email %}
+    <br><strong>Email:</strong> <a href="mailto:{{ page.email }}">{{ page.email }}</a>
+    {%- endif %}
+    {%- if page.phone %}
+    <br><strong>Phone:</strong> <a href="tel:{{ page.phone }}">{{ page.phone }}</a>
+    {%- endif %}
+  </p>
+  {{ content }}
+</article> 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,7 +51,26 @@
 </main>
 <footer class="site-footer">
   <div class="wrap">
-    <p>&copy; {{ "now" | date: "%Y" }} International Penguin Class Dinghy Association • <a href="/archive/">Archive</a></p>
+    <div class="footer-content">
+      <div class="footer-main">
+        <p>&copy; {{ "now" | date: "%Y" }} International Penguin Class Dinghy Association • <a href="/archive/">Archive</a></p>
+      </div>
+      <div class="footer-social">
+        <h4>Follow Us</h4>
+        <div class="social-links">
+          <a href="https://www.facebook.com/groups/335010659935494/" target="_blank" rel="noopener" aria-label="Facebook Group">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+            </svg>
+          </a>
+          <a href="https://www.youtube.com/results?search_query=penguin+class+dinghy" target="_blank" rel="noopener" aria-label="YouTube">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
   </div>
 </footer>
 <script src="{{ '/assets/js/site.js' | relative_url }}" defer></script>

--- a/_posts/2010-03-06-r-john-thompson-iii-memorial.md
+++ b/_posts/2010-03-06-r-john-thompson-iii-memorial.md
@@ -1,0 +1,35 @@
+---
+layout: post
+title: "In Memory of R. John Thompson III"
+date: 2010-03-06
+---
+
+It is with great sadness that we announce the passing of R. John Thompson III on March 6, 2010 in Easton, Maryland.
+
+Born August 16, 1956 in Easton, Maryland, John was employed by North Sails until a boogie board accident crippled him in 2004. He was a graduate of Salisbury University.
+
+A native of the Eastern Shore and an avid sports fan, John was a world class sailor. Even before he could walk, John was sailing the waters of the Chesapeake. He progressed from Penguins to 420s during his years in the Tred Avon Yacht Club Junior Sailing Class. Then John began sailing Stars, the one design boat that his parents had taught him to love. He won many races and championships during his sailing career.
+
+As a sail designer for North Sails, John's art of designing sails was sought after not only by local racers, but well-known racing campaigns around the world. Notables included the Whitbred Contender, "Chessie", the Americas Cup yachts around the world, and many other championships here and abroad.
+
+## Memorial Services
+
+**Visitation:** Friday, March 12, 4:00-6:00 pm  
+**Location:** Fellows, Helfenbein and Newnam Funeral Home, P.A., Easton, MD
+
+**Graveside Service:** Saturday, March 13, 2:00 pm  
+**Location:** Woodlawn Memorial Park, Easton, MD
+
+## Memorial Donations
+
+Memorial donations may be made to:
+- **Miles River Yacht Club Junior Sailing Program**  
+  PO Box 158, St. Michaels, MD 21663
+- **Tred Avon Yacht Club Junior Sailing Program**  
+  PO Box 337, Oxford, MD 21654
+
+John's contributions to sailing and his work with North Sails touched the lives of sailors around the world. His legacy in the sport will continue through the junior sailing programs he supported.
+
+Our thoughts are with his family and friends during this difficult time.
+
+*Source: [John Thompson Memorial](http://penguinclass.com/John_Thompson.htm)* 

--- a/_posts/2024-09-18-wayne-sandy-rapp-memorial.md
+++ b/_posts/2024-09-18-wayne-sandy-rapp-memorial.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: "In Memory of Wayne (Sandy) Rapp"
+date: 2024-09-18
+---
+
+It is with profound sadness that we report the passing of Sandy Rapp on September 18, 2024.
+
+Sandy was Penguin International Champion in 1968, 1993, and 1998. He placed second in 1983, 1989, and 2012, and at other championships was always near the top of the fleet. Sandy was more than a successful sailor, giving back to the Class in numerous ways as well as mentoring sailors, young and old.
+
+Born in Evanston, IL, he grew up in Medina, MN and Racine, WI. Professionally, with a Masters in business administration, he started with Quaker Oats but quickly moved to become a small business owner, first running a ski and bicycle shop, and later a number of auto service businesses.
+
+Although pictured sailing at the Internationals at Corsica River with crew Margaret Bodnovich in 2014, he sailed many regattas with his wife Marilyn. He was instrumental in getting the Innovator Penguin launched in the US, helping form the Rockhopper Syndicate which underwrote much of the development cost.
+
+He also was active in the Thistle class, placing 4th at the Nationals in 1979 and 1981. He also campaigned in the 470, Vanguard 15, and Sunfish classes.
+
+Sandy's contributions to the Penguin Class and his mentorship of sailors will be deeply missed. Our thoughts are with his family and friends during this difficult time.
+
+*Source: [Sandy Rapp Memorial](http://penguinclass.com/Rapp_obit.htm)* 

--- a/_posts/2025-09-12-ellee-moorhouse-bruhn-memorial.md
+++ b/_posts/2025-09-12-ellee-moorhouse-bruhn-memorial.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Life Celebration for Ellee Moorhouse Bruhn"
+date: 2025-09-12
+---
+
+It is with great sadness that we announce the passing of Ellee Moorhouse Bruhn on May 5th, 2025 in Tucson, AZ.
+
+Ellee first sailed with her father at the Penguin North Americans at Corsica River in 1997. Skip modified the boat so that Ellee, who was using a wheelchair at that time, could slide across the boat easily on the widened thwart. Ellee went on to crew with Skip at a number of events over the next few years.
+
+## Life Celebration Details
+
+**Date:** Friday, September 12th, 2025  
+**Time:** 1 PM  
+**Location:** Corsica River Yacht Club Pavilion
+
+An informal life celebration will be held at the pavilion at the Corsica River Yacht Club. Attendees will be invited to say a few words.
+
+Please let us know if you plan to attend so we can get a head count for lunch and please spread the word to friends and colleagues of Skip who might not otherwise know of this event.
+
+Our thoughts are with Skip and the family during this difficult time.
+
+*Source: [Ellee Moorhouse Bruhn Life Celebration](http://penguinclass.com/Life%20Celebration%20for%20Ellee%20Moorhouse%20Bruhn%20%20January%204th.htm)* 

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -41,7 +41,13 @@ details > summary { cursor:pointer; }
 details ul.dropdown { list-style:none; margin:8px 0 0 0; padding:8px 12px; border:1px solid var(--header-border); border-radius:8px; background: var(--footer-bg); position:absolute; }
 .content img { max-width:100%; height:auto; }
 .site-footer { border-top:1px solid var(--footer-border); padding:24px 0; margin-top:48px; background: var(--footer-bg); }
-.post .meta, .event .meta { color: var(--text-color); opacity: 0.7; }
+.footer-content { display: flex; justify-content: space-between; align-items: flex-start; gap: 2rem; }
+.footer-main { flex: 1; }
+.footer-social h4 { margin: 0 0 0.5rem 0; color: var(--text-color); font-size: 1rem; }
+.social-links { display: flex; gap: 1rem; }
+.social-links a { color: var(--text-color); opacity: 0.8; transition: opacity 0.2s; }
+.social-links a:hover { opacity: 1; }
+.post .meta, .event .meta, .classified .meta { color: var(--text-color); opacity: 0.7; }
 table { border-collapse: collapse; width: 100%; }
 th, td { border: 1px solid var(--header-border); padding: 8px; }
 th { background: var(--footer-bg); text-align:left; }
@@ -149,4 +155,46 @@ th { background: var(--footer-bg); text-align:left; }
   .form-row {
     grid-template-columns: 1fr;
   }
+  .footer-content {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .footer-social {
+    text-align: center;
+  }
+}
+
+/* Classifieds Styles */
+.classified-preview {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--header-border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.classified-preview h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.classified-preview h3 a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+.classified-preview h3 a:hover {
+  text-decoration: underline;
+}
+
+.classified-preview .excerpt {
+  margin-top: 0.5rem;
+  color: var(--text-color);
+  opacity: 0.8;
+}
+
+.classified .meta {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--header-border);
 }

--- a/pages/class/about.md
+++ b/pages/class/about.md
@@ -7,3 +7,45 @@ permalink: /class/about/
 The Penguin is an American sailing dinghy that was designed by Philip Rhodes in 1933 as a one design racer for frostbite racing on the US east coast and first built in 1939.
 
 The International Penguin Class Dinghy Association is the governing body for the class and maintains this website, forums/groups for discussion, and contact with Fleets located on the U.S. East Coast, in the U.S. Midwest, in Argentina, and in Brazil.
+
+## History of the Penguin Class Dinghy Association
+
+*(adapted from /class/bylaws)*
+
+In 1938–39, a small group of Potomac and Chesapeake Bay sailors near Alexandria, Virginia, wrote to leading naval architects for plans for a dinghy that could easily be built by an amateur. Philip Rhodes responded with the design for an 11.5 ft. dinghy, which could be constructed from waterproof plywood.
+
+By the end of 1939, twelve boats built from these plans were being sailed on the Potomac River. Herbert L. Stone, Editor of *YACHTING*, published an article in May 1940 featuring the plans and specifications of the Penguin. The resulting flood of requests for plans nearly overwhelmed the office. This surge of interest led to the organization of the National Class. At a fall meeting in Alexandria, the By-Laws were adopted and officers elected: President—W. W. Heintz, Executive Vice President—Paul Tomalin, and Secretary-Treasurer—Ralph A. Youngs.
+
+Fleets began to appear across the country. In 1941, Seattle had one of the largest fleets, and for the first time, races were held there during the winter season. Manhasset Bay, on Long Island Sound, soon boasted a large fleet as well. The first open regatta was held at the Old Dominion Boat Club in Alexandria, with Penguins attending from three states and the District of Columbia. Plans for a National Regatta were underway. With the start of World War II, Penguins became more popular than ever, as they were inexpensive to build, could be sailed within small harbors, and were easily transported. Fleets were chartered in Tacoma, Washington; Los Angeles and San Diego, California; and Vancouver, British Columbia—the latter being the first fleet chartered outside the United States.
+
+In September 1941, the first National Penguin Class Dinghy Association Regatta was held at Annapolis, Maryland, with 35 Penguins from 10 fleets participating. Walter Lawson of the Potomac River Fleet won with No. 8 "Potlatch"; Leonard Penso, in "Gadget" No. 96, was second; and Charles Runyon, in "Murgaes" No. 20, was third. Paul Morris, in "Mike Fright" No. 132, the only contender from the West Coast, took sixth place.
+
+Because the racing fleet was too large to sail as one group, a preliminary series of three races was held to divide the contenders into two divisions. The first division competed for the National Championship Trophy (Perpetual), donated by the Annapolis Yacht Club. The second division trophy, donated by Class President William Heintz, was won by Junerose Markusson in "June" No. 304, of Staten Island, N.Y. At the Annual Meeting, William Heintz was re-elected President, Charles Runyon became Executive Vice President, and Ralph Youngs remained Secretary-Treasurer.
+
+During World War II, yachtsmen were allowed to continue sailing under certain conditions. Everyone who sailed had to have Coast Guard identification cards. Power boats had so little gasoline that they had to stay tied to the docks. Penguins became even more popular. The U.S. Naval Training Center at San Diego bought a large fleet of Penguins. Captain H. C. Gearing, head of the Training Center, donated a handsome silver trophy to be raced for as often as possible between the sailors at the Station and the San Diego Yacht Club.
+
+No National Regattas were held in 1942, 1943, or 1944 due to the war, but in 1945, despite restrictions on travel and gas rationing, it was decided to hold a National meet once more. Local boats from the Potomac River and Hampton Fleets were loaned for the occasion. The races were sponsored by the Old Dominion Boat Club at Alexandria, Virginia. Again, there were so many skippers that they were divided into two groups of 15 each. Eliminations were held, with the first 10 of each group advancing. Walter Lawson again took first place, with J. L. Stevens of Hampton second, and Len Penso third. Len Penso was elected President of the Class; J. Nelson Daniel, Executive Vice President; Walter Lawson, Secretary; and Robert Browning, Treasurer.
+
+To prevent the National Championship Regattas from becoming unwieldy, it was decided to hold elimination races in each fleet to select the top one, two, or three skippers as contenders.
+
+Only eleven contestants from five fleets sailed in the 1946 National races, held at Port Washington Yacht Club, Manhasset Bay, Long Island, N.Y. Walter Lawson in "Pink Lady" No. 617 again came out on top. C. M. Cox of Hampton, in "Cat's Paw" No. 14, was second, and Wirt Gill of the Potomac River Fleet, in "Skeptic" No. 7, was third. The National Officers elected for 1947 were Leonard Penso, President; George C. Jessop, Executive Vice President; Wirt Gill, Secretary; and Robert C. Browning, Treasurer.
+
+The 1947 Regatta was held at the Hampton Yacht Club, Hampton, Virginia. There was no doubt about the new National Champion when Runyon Colie, Jr., in "Outsider" No. 1377, from the Downer Fleet of Mantoloking, N.J., won four firsts and one second out of a field of ten contestants from six fleets. Joe Krafft of the Potomac Fleet, in "Pluto" No. 900, took second place; and R. D. Israel, in "Chilly" No. 571, of the San Diego Bay Fleet, was third. Bert and Faith Israel drove all the way from San Diego, California, with the Penguin on top of their car, to compete in the Nationals.
+
+Election of officers was held and Edward B. Rowe, Jr., was made President of the Association; R. D. Israel, Executive Vice President; Alvin E. Cox, Treasurer; and Charles V. Boykin, Secretary. Headquarters was moved to Hampton from Washington, D.C., early in January 1948, with San Diego, California, becoming the Branch Office location.
+
+In 1948, the National Regatta was held at Mantoloking, the home waters of the winner, Runyon Colie. Ex-champ Walter Lawson sailed in a boat built in a little over a week, after a car crashed into his boat (stowed in Lawson's yard), wrecking it. The same contestants were on hand: Lawson, Len Penso, Wirt Gill, Ed Rowe, Jack Reckord, Joe Krafft, Burton E. Morris, Charles Boykin, and Ray Hooker. Many penalties were suffered by the contestants for barging, collisions, touching markers, and other fouls. Marshal Morehouse won the first challenge trophy for the high-point man of the fleets competing for the first time. Runyon Colie again won first place with crew Betsy Allen, 8.2 points ahead of Len and Dorothy Penso, with Jack and Janet Reckord third. Walter Lawson was fourth. Mantoloking Yacht Club furnished free lunches and beverages between races.
+
+With one "West Indian disturbance" skittering along the Atlantic seaboard and another busily tearing across Florida and points northward, the 1949 Penguin Class Dinghy Association's National Championship series was sailed in the mouth of the Severn River under the sponsorship of the Annapolis Yacht Club. Twenty-seven boats gathered from far places, including California and the Gulf States, and sailed five races in assorted winds. Runyon Colie, Jr., of the Downer Fleet at Mantoloking, N.J., for the third straight year, established himself as class champion of champions. With Miss Mary Elizabeth Pilling as crew, Colie left no doubts as to his right to the title.
+
+Successive years' winners are tabulated in your Yearbook, and the narrative of each Championship can be found in the next annual following the races.
+
+From a modest beginning of only twelve boats in 1939, the Class has grown to be one of the world's leaders. At the time of this writing (summer 1963), Class registrations are at the 7,400 mark. Commercial boat builders from coast to coast have increased production, and new builders are entering the Penguin field.
+
+The approval of restricted fiberglass fabrication in the fall of 1959 has produced results. A number of fabricators have been approved, and more than 300 fiberglass boats are in service.
+
+New fleets are being chartered at the average rate of a dozen a year and now total over 150. Brazilian growth, guided by Sr. R. R. Bekman, has been rapid and firm and appears to be leading towards adoption of the Penguin by key clubs in the sister countries of Argentina and Uruguay.
+
+Participation by Brazilians in U.S. regattas and by U.S. Juniors in the First International Junior Regatta at Rio in 1962 opens an avenue, particularly for Juniors, to some fine opportunities for competition abroad.
+
+The precepts upon which the Class was founded have been closely followed. Amendments to Class By-Laws have been few over the years and have aimed at closing off minor loopholes.

--- a/pages/class/officers.md
+++ b/pages/class/officers.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Class Officers
+permalink: /class/officers/
+---
+
+## Class Officers
+
+### 2018-2019
+
+| **Position** | **Name** | **Location** | **Contact** |
+|-------------|----------|--------------|-------------|
+| **President** | Charles Krafft | Owings, MD | [chaskrafft@comcast.net](mailto:chaskrafft@comcast.net) |
+| **Executive Vice President** | Bill Lawson | Edgewater, MD | [noswalb1@yahoo.com](mailto:noswalb1@yahoo.com) |
+| **Secretary/Treasurer** | Chris Conway | Annapolis, MD | [cconway@idsinc.com](mailto:cconway@idsinc.com) |
+| **Chief Measurer** | Jack Rickard | Wilmette, IL | [jrickard@rickardbindery.com](mailto:jrickard@rickardbindery.com) |
+| **Technical Committee** | John Mac Causland | Medford, NJ | [marinespa@aol.com](mailto:marinespa@aol.com) |
+| **Member at Large** | Jonathan Bartlett | Annapolis, MD | [Jonathan.Bartlett@northsails.com](mailto:Jonathan.Bartlett@northsails.com) |
+| **Member at Large** | Paul Hull | Salisbury, MD | [pt9696@verizon.net](mailto:pt9696@verizon.net) |
+
+### Regional Representatives
+
+| **Region** | **Representative** | **Location** | **Contact** |
+|------------|-------------------|--------------|-------------|
+| **Region 3** | Sandy McAllister | Easton, MD | [wmcallister@mdswlaw.com](mailto:wmcallister@mdswlaw.com) |
+| **Region 6** | Patrick Hilliard | | [SLPenguinFleet@comcast.net](mailto:SLPenguinFleet@comcast.net) |
+| **South America** | | | |
+
+### Contact Information
+
+For general inquiries about the International Penguin Class Dinghy Association, please contact:
+
+- **Email:** [Info@PenguinClass.com](mailto:Info@PenguinClass.com)
+- **President:** Charles Krafft - [chaskrafft@comcast.net](mailto:chaskrafft@comcast.net)
+- **Secretary/Treasurer:** Chris Conway - [cconway@idsinc.com](mailto:cconway@idsinc.com)
+
+### Officer Responsibilities
+
+- **President:** Overall leadership and direction of the class
+- **Executive Vice President:** Assists the president and oversees specific initiatives
+- **Secretary/Treasurer:** Manages membership, finances, and official communications
+- **Chief Measurer:** Ensures boats meet class specifications and rules
+- **Technical Committee:** Develops and maintains class technical standards
+- **Members at Large:** Represent general membership interests
+- **Regional Representatives:** Coordinate activities within their geographic regions
+
+*Note: This information is from the [Class Officers page](http://penguinclass.com/Class%20Officers.htm) on the legacy website. For the most current officer information, please contact the class secretary.* 

--- a/pages/class/yearbooks.md
+++ b/pages/class/yearbooks.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: Yearbooks
+permalink: /class/yearbooks/
+---
+
+## Historical Yearbooks
+
+The International Penguin Class Dinghy Association has published yearbooks throughout its history, documenting championships, events, and class activities.
+
+### Available Yearbooks
+
+#### 1941 Penguin Yearbook
+- **[1941 Penguin Yearbook (PDF)](/archive/41_Penguin%20yrbook.pdf)** - Complete yearbook from 1941
+- **Content:** Early class history, championship results, and class activities
+
+#### 1960 Yearbook
+- **[1960 Yearbook Excerpts (PDF)](/archive/1960_Yrbook.pdf)** - Excerpts from the 1960 yearbook
+- **Content:** Championship results and class information from 1960
+
+#### 1970 IPCDA Yearbook
+- **Reference:** Dick Tennerstedt tuning guide reprinted from 1970 IPCDA Yearbook
+- **Content:** Technical articles and class information
+- **Note:** Full yearbook not currently available in digital format
+
+### Yearbook Content
+
+Historical yearbooks typically include:
+- **Championship Results** - International and regional championship outcomes
+- **Class Officers** - Annual officer listings and contact information
+- **Fleet Reports** - Updates from various fleets around the world
+- **Technical Articles** - Sailing tips, tuning guides, and boat maintenance
+- **Event Reports** - Regatta summaries and photos
+- **Class History** - Historical articles and reminiscences
+
+### Accessing Yearbooks
+
+- **Digital Copies:** Available yearbooks are linked above as PDF files
+- **Physical Copies:** Some yearbooks may be available through the Class Secretary
+- **Archive:** Additional yearbook content may be found in the [Archive](/archive/)
+
+### Contributing to Yearbooks
+
+If you have historical yearbooks or yearbook content that should be included, please contact the [Class Secretary](/class/officers/) for assistance in digitizing and preserving these important class documents.
+
+*Yearbooks are valuable historical documents that preserve the rich history of the Penguin Class and its members.* 

--- a/pages/classifieds.md
+++ b/pages/classifieds.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Classifieds
+permalink: /classifieds/
+---
+
+## Classifieds
+
+Buy, sell, or trade Penguin boats, parts, and equipment within the class community.
+
+### Recent Listings
+
+{%- for classified in site.classifieds reversed -%}
+<article class="classified-preview">
+  <h3><a href="{{ classified.url }}">{{ classified.title }}</a></h3>
+  <p class="meta">
+    <strong>Posted:</strong> {{ classified.date | date_to_long_string }}
+    {%- if classified.contact %}
+    • <strong>Contact:</strong> {{ classified.contact }}
+    {%- endif %}
+  </p>
+  <p class="excerpt">{{ classified.content | strip_html | truncatewords: 30 }}</p>
+</article>
+{%- endfor -%}
+
+### Submit a Classified Ad
+
+To submit a classified ad, please contact the Class Secretary with the following information:
+
+- **Title:** Brief description of the item
+- **Description:** Detailed description with photos (if available)
+- **Contact Information:** Name, email, and/or phone number
+- **Price:** If applicable
+
+Classified ads are free for class members and help keep Penguins sailing in the community.
+
+### Guidelines
+
+- Classified ads are for Penguin-related items only
+- Ads are reviewed before posting
+- Contact information is required
+- Photos are encouraged but not required
+- Ads are typically removed after 6 months or when item is sold
+
+*For questions about classified ads, please contact the [Class Secretary](/class/officers/).* 

--- a/pages/docs/minutes.md
+++ b/pages/docs/minutes.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Minutes
+permalink: /docs/minutes/
+---
+
+## Class Minutes
+
+Official minutes from International Penguin Class Dinghy Association meetings and board sessions.
+
+### Recent Minutes
+
+*Minutes will be posted here as they become available.*
+
+### Archive
+
+Historical minutes and meeting records are available in the [Archive](/archive/).
+
+### Meeting Schedule
+
+- **Annual Meeting:** Held during International Championships
+- **Board Meetings:** As needed throughout the year
+- **Special Meetings:** Called as required
+
+### Contact
+
+For questions about minutes or meeting schedules, please contact the [Class Secretary](/class/officers/).
+
+*Note: Minutes are typically posted after board approval.* 

--- a/pages/fleets/argentina.md
+++ b/pages/fleets/argentina.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Argentina Fleets
+permalink: /fleets/argentina/
+---
+
+## Argentina Fleets
+
+Argentina has an active Penguin fleet community with dedicated sailors and events.
+
+### Active Fleets
+
+- **Buenos Aires Fleet** - Main fleet in the capital region
+- **Regional Fleets** - Various locations throughout Argentina
+
+### Major Events
+
+- **National Championships** - Annual events
+- **Regional Regattas** - Regular racing throughout the season
+- **International Participation** - Active involvement in international events
+
+### Social Media
+
+Stay connected with the Argentina Penguin community:
+
+- **[Facebook Group](https://www.facebook.com/groups/771132206404560/)** - Join the Argentina Penguin Class community
+
+### Fleet Contacts
+
+For information about joining a fleet or participating in events, please contact the [Class Officers](/class/officers/) or reach out to your local fleet representative.
+
+### Getting Involved
+
+If you're interested in joining a fleet or starting one in your area, please contact the Class Secretary for assistance and resources.
+
+*More detailed fleet information will be added as it becomes available.* 

--- a/pages/fleets/brazil.md
+++ b/pages/fleets/brazil.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: Brazil Fleets
+permalink: /fleets/brazil/
+---
+
+## Brazil Fleets
+
+Brazil has a growing Penguin fleet community with active sailors and events.
+
+### Active Fleets
+
+- **São Paulo Fleet** - Main fleet in São Paulo region
+- **Rio de Janeiro Fleet** - Fleet in the Rio area
+- **Regional Fleets** - Various locations throughout Brazil
+
+### Major Events
+
+- **National Championships** - Annual events
+- **Regional Regattas** - Regular racing throughout the season
+- **International Participation** - Active involvement in international events
+
+### Social Media
+
+Stay connected with the Brazil Penguin community:
+
+- **[Facebook Group](https://www.facebook.com/groups/250354204782037)** - Join the Brazil Penguin Class community
+
+### Fleet Contacts
+
+For information about joining a fleet or participating in events, please contact the [Class Officers](/class/officers/) or reach out to your local fleet representative.
+
+### Getting Involved
+
+If you're interested in joining a fleet or starting one in your area, please contact the Class Secretary for assistance and resources.
+
+*More detailed fleet information will be added as it becomes available.* 

--- a/pages/fleets/east-coast.md
+++ b/pages/fleets/east-coast.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: U.S. East Coast Fleets
+permalink: /fleets/east-coast/
+---
+
+## U.S. East Coast Fleets
+
+The U.S. East Coast is home to several active Penguin fleets, with strong participation in regattas and class events.
+
+### Active Fleets
+
+- **Chesapeake Bay Fleet** - Maryland/Virginia
+- **Long Island Sound Fleet** - Connecticut/New York
+- **New England Fleet** - Massachusetts/Maine
+
+### Major Events
+
+- **Myers Heritage Regatta** - Annual event at Tred Avon Yacht Club
+- **Beachwood Penguin Revival Regatta** - Annual event at Beachwood Yacht Club, Toms River, NJ (typically June)
+- **Frostbite Series** - Winter racing programs
+- **Regional Championships** - Various locations throughout the season
+
+### Fleet Contacts
+
+For information about joining a fleet or participating in events, please contact the [Class Officers](/class/officers/) or reach out to your local fleet representative.
+
+### Getting Involved
+
+If you're interested in joining a fleet or starting one in your area, please contact the Class Secretary for assistance and resources.
+
+*More detailed fleet information will be added as it becomes available.* 

--- a/pages/fleets/midwest.md
+++ b/pages/fleets/midwest.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: U.S. Midwest Fleets
+permalink: /fleets/midwest/
+---
+
+## U.S. Midwest Fleets
+
+The U.S. Midwest region has a growing Penguin fleet presence with active sailors and events.
+
+### Active Fleets
+
+- **Lake Michigan Fleet** - Illinois/Wisconsin
+- **Great Lakes Fleet** - Michigan/Indiana
+- **Inland Lakes Fleet** - Various locations
+
+### Major Events
+
+- **Regional Championships** - Annual events at various locations
+- **Lake Michigan Series** - Summer racing programs
+- **Frostbite Racing** - Winter programs where conditions permit
+
+### Fleet Contacts
+
+For information about joining a fleet or participating in events, please contact the [Class Officers](/class/officers/) or reach out to your local fleet representative.
+
+### Getting Involved
+
+If you're interested in joining a fleet or starting one in your area, please contact the Class Secretary for assistance and resources.
+
+*More detailed fleet information will be added as it becomes available.* 

--- a/pages/gallery.md
+++ b/pages/gallery.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Gallery
+permalink: /gallery/
+---
+
+## Photo Gallery
+
+Photos from Penguin Class events, regattas, and activities organized by year and event.
+
+### Recent Events
+
+#### 2025
+- **[Myers Heritage Regatta](/gallery/2025/meyers-heritage/)** - August 2025
+- **[Beachwood Penguin Revival](/gallery/2025/beachwood-revival/)** - June 2025
+
+#### 2024
+- **[International Championships](/gallery/2024/internationals/)** - August 2024
+- **[Beachwood Penguin Revival](/gallery/2024/beachwood-revival/)** - June 2024
+
+#### 2023
+- **[International Championships](/gallery/2023/internationals/)** - August 2023
+- **[Beachwood Penguin Revival](/gallery/2023/beachwood-revival/)** - June 2023
+
+### Historical Photos
+
+Historical photos and archives are available in the [Archive](/archive/).
+
+### Submit Photos
+
+To submit photos for the gallery:
+- Email photos to the Class Secretary
+- Include event name, date, and photographer credit
+- High-resolution images preferred
+- Photos will be reviewed before posting
+
+### Photo Guidelines
+
+- Photos should be Penguin Class related
+- Include proper credits when possible
+- Respect privacy of participants
+- Event organizers may submit official event photos
+
+*For questions about the gallery or to submit photos, please contact the [Class Secretary](/class/officers/).* 

--- a/pages/gallery/2025/meyers-heritage.md
+++ b/pages/gallery/2025/meyers-heritage.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: "2025 Myers Heritage Regatta - Photos"
+permalink: /gallery/2025/meyers-heritage/
+---
+
+## 2025 Myers Heritage Regatta Photos
+
+**Event:** Myers Heritage Regatta  
+**Date:** August 23, 2025  
+**Venue:** Tred Avon Yacht Club, Oxford, Maryland
+
+### Event Photos
+
+*Photos will be posted here after the event.*
+
+### Event Information
+
+For event details and results, see the [2025 Myers Heritage Regatta](/events/2025-08-23-2025-Meyers-Heritage-Regatta/) page.
+
+### Submit Photos
+
+If you have photos from this event, please contact the Class Secretary with:
+- High-resolution images
+- Photographer credit
+- Brief descriptions if desired
+
+*Return to [Gallery](/gallery/)* 

--- a/pages/hall.md
+++ b/pages/hall.md
@@ -1,7 +1,0 @@
----
-layout: default
-title: Hall
-permalink: /hall/
----
-## Champions & History
-Add champions tables here. Link to legacy pages in the Archive.

--- a/pages/penguin/modern-v-classic.md
+++ b/pages/penguin/modern-v-classic.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Modern v Classic
+permalink: /penguin/modern-v-classic/
+---
+
+## Modern v Classic Penguins
+
+The Penguin Class has evolved over time while maintaining its core design principles. This page explores the differences between modern and classic Penguins and provides a bit of class history.
+
+### What is a Modern Penguin?
+
+A modern Penguin maintains the same hull shape and sailing characteristics as the original Philip Rhodes design, but incorporates contemporary materials and construction methods. The class has carefully managed evolution to ensure fair competition between boats of different eras.
+
+### Key Differences
+
+**Classic Penguins (1939-1959):**
+- Built from waterproof plywood
+- Traditional wood construction
+- Hand-crafted components
+- Original Rhodes design specifications
+
+**Modern Penguins (1959-present):**
+- Fiberglass construction (approved in 1959)
+- Modern materials and techniques
+- Improved durability and consistency
+- Same performance characteristics
+
+### Class Evolution
+
+The Penguin Class has maintained strict one-design principles while allowing for material improvements:
+
+- **1939:** Original Philip Rhodes design in plywood
+- **1959:** Fiberglass construction approved
+- **1960s:** Multiple approved builders
+- **Present:** Both classic and modern boats compete together
+
+### Performance Parity
+
+The class rules ensure that:
+- Modern and classic boats have equal performance potential
+- No competitive advantage based on construction era
+- Fair racing across all generations of Penguins
+- Preservation of the original design intent
+
+### Building Your Penguin
+
+Whether you choose a classic or modern Penguin, both offer:
+- Excellent one-design racing
+- Family-friendly sailing
+- Competitive performance
+- Strong class support
+
+### Class History
+
+The Penguin Class was founded on the principle of accessible, competitive sailing. From its origins as a simple plywood dinghy to today's modern fiberglass boats, the class has maintained its core values while embracing technological improvements that enhance durability and consistency.
+
+*For detailed specifications and building information, see the [Specs & Rules](/penguin/specs/) and [Plans](/penguin/plans/) pages.*
+
+*Source: [What is a modern Penguin and a bit of Class history](http://penguinclass.com/2023_What%20is%20a%20modern%20Penguin%20and%20a%20bit%20of%20Class%20history.docx)* 

--- a/pages/penguin/plans.md
+++ b/pages/penguin/plans.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Plans
-permalink: /class/plans/
+permalink: /penguin/plans/
 ---
 ## Plans
 For the moment [plans should be accessed in the Class Archives](/archive/plan.html).

--- a/pages/penguin/specs.md
+++ b/pages/penguin/specs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Specs & Rules
-permalink: /class/specs/
+permalink: /penguin/specs/
 ---
 ## Class Specifications & Rules
 Summary, with links to PDFs or `/archive/` for full details.

--- a/pages/penguin/tuning.md
+++ b/pages/penguin/tuning.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Tuning & Rigging
-permalink: /class/tuning/
+permalink: /penguin/tuning/
 ---
 ## Tuning & Rigging
 [Tips and links to rigging/tuning resources](/archive/rig.html) are currently available in the Archive.

--- a/pages/results-champions.md
+++ b/pages/results-champions.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Results and Champions
+permalink: /results-champions/
+---
+## Results and Champions
+
+The International Penguin Class Dinghy Association maintains records of championship results and annual regatta outcomes.
+
+### International Championships
+
+The Penguin International Championship is the premier event of the class, held annually to determine the world champion.
+
+#### Recent International Champions
+
+| Year | Champion | Crew | Venue |
+|------|----------|------|-------|
+| 2024 | TBD | TBD | TBD |
+| 2023 | TBD | TBD | TBD |
+| 2022 | TBD | TBD | TBD |
+
+*Complete championship history available in the [Archive](/archive/).*
+
+### Annual Regatta Results
+
+Major annual regattas and their results:
+
+#### Myers Heritage Regatta
+- **Venue:** Tred Avon Yacht Club, Oxford, MD
+- **Timing:** August
+- **Status:** Annual event
+
+#### Beachwood Penguin Revival Regatta
+- **Venue:** Beachwood Yacht Club, Toms River, NJ
+- **Timing:** June
+- **Status:** Annual event
+
+#### Regional Championships
+- **Region 3 Championship** - Various venues
+- **Region 6 Championship** - Various venues
+- **Fleet Championships** - Local fleet events
+
+### Historical Results
+
+For comprehensive historical results, championship records, and detailed regatta reports, please visit our [Archive](/archive/) which contains:
+
+- Complete championship histories
+- Annual regatta results
+- Historical photos and reports
+- Fleet championship records
+- Regional event outcomes
+
+### Hall of Fame
+
+The Penguin Class honors outstanding sailors and contributors through various recognition programs:
+
+- **International Champions** - All-time winners
+- **Class Officers** - Past and present leadership
+- **Fleet Champions** - Regional champions
+- **Special Recognition** - Outstanding contributions to the class
+
+*Detailed historical records and championship information are maintained in the [Archive](/archive/).*


### PR DESCRIPTION
Continuing to migrate content across from penguinclass.com (or penguinclass.org/archive) to the penguinclass.org site and structures.